### PR TITLE
Fix empty lines output on the product page

### DIFF
--- a/afwp.php
+++ b/afwp.php
@@ -36,6 +36,7 @@ function afwp_product_meta() {
 		{
 			foreach( $fields as $field_name => $field )
 			{
+				if ($field_name == '') continue;
 		?>
 				<span class="posted_in">
 					<?php echo $field['label'].': ';


### PR DESCRIPTION
I had a bug with this plugin where it printed empty lines on product pages, so I tried to skip empty lines.